### PR TITLE
Fix page title for twig template

### DIFF
--- a/templates/disco.twig
+++ b/templates/disco.twig
@@ -1,4 +1,4 @@
-{% set pagetitle = 'selectidp'|trans %}
+{% set pagetitle = '{disco:selectidp}'|trans %}
 {% extends "base.twig" %}
 
 {% block preload %}

--- a/templates/disco.twig
+++ b/templates/disco.twig
@@ -1,4 +1,4 @@
-{% set pagetitle = '{disco:selectidp}'|trans %}
+{% set pagetitle = 'Select your identity provider'|trans %}
 {% extends "base.twig" %}
 
 {% block preload %}


### PR DESCRIPTION
Set pagetitle = 'selectidp' was not fetching the dictionary item for the
page title, thus when visiting discovery, all you see is "selectidp" in the header.