### PR TITLE
eduGAIN > Europe

### DIFF
--- a/dictionaries/tabs.definition.json
+++ b/dictionaries/tabs.definition.json
@@ -27,7 +27,7 @@
 		"en": "South Africa"
 	},
 	"edugain": {
-		"en": "Europe (eduGAIN)"
+		"en": "eduGAIN"
 	},
 	"misc": {
 		"en": "Miscellaneous"

--- a/dictionaries/tabs.translation.json
+++ b/dictionaries/tabs.translation.json
@@ -116,17 +116,17 @@
 		"ca": "Sud-Àfrica"
 	},
 	"edugain": {
-		"es": "Europa (eduGAIN)",
-		"ru": "\u0415\u0432\u0440\u043e\u043f\u0430 (eduGAIN)",
-		"zh-tw": "\u6b50\u6d32 (eduGAIN)",
-		"nl": "Europa (eduGAIN)",
-		"gl": "Europa (eduGAIN)",
-		"da": "Europa (eduGAIN)",
-		"af": "Europa (eduGAIN)",
-		"el": "\u0395\u03c5\u03c1\u03ce\u03c0\u03b7 (eduGAIN)",
-		"xh": "Yurophu (eduGAIN)",
-		"zu": "IYurophu (eduGAIN)",
-		"ca": "Europa (eduGAIN)"
+		"es": "eduGAIN",
+		"ru": "eduGAIN",
+		"zh-tw": "eduGAIN",
+		"nl": "eduGAIN",
+		"gl": "eduGAIN",
+		"da": "eduGAIN",
+		"af": "eduGAIN",
+		"el": "eduGAIN",
+		"xh": "eduGAIN",
+		"zu": "eduGAIN",
+		"ca": "eduGAIN"
 	},
 	"misc": {
 		"es": "Otros",

--- a/locales/af/LC_MESSAGES/discopower.po
+++ b/locales/af/LC_MESSAGES/discopower.po
@@ -36,7 +36,7 @@ msgid "{discopower:tabs:sweden}"
 msgstr "Swede"
 
 msgid "{discopower:tabs:edugain}"
-msgstr "Europa (eduGAIN)"
+msgstr "eduGAIN"
 
 msgid "{discopower:tabs:iceland}"
 msgstr "Ysland"
@@ -86,8 +86,8 @@ msgstr "Verskeie"
 msgid "Finland"
 msgstr "Finland"
 
-msgid "Europe (eduGAIN)"
-msgstr "Europa (eduGAIN)"
+msgid "eduGAIN"
+msgstr "eduGAIN"
 
 msgid "InCommon"
 msgstr "InCommon"

--- a/locales/da/LC_MESSAGES/discopower.po
+++ b/locales/da/LC_MESSAGES/discopower.po
@@ -37,7 +37,7 @@ msgid "{discopower:tabs:sweden}"
 msgstr "Sverige"
 
 msgid "{discopower:tabs:edugain}"
-msgstr "Europa (eduGAIN)"
+msgstr "eduGAIN"
 
 msgid "{discopower:tabs:iceland}"
 msgstr "Island"
@@ -87,8 +87,8 @@ msgstr "Forskellige"
 msgid "Finland"
 msgstr "Finland"
 
-msgid "Europe (eduGAIN)"
-msgstr "Europa (eduGAIN)"
+msgid "eduGAIN"
+msgstr "eduGAIN"
 
 msgid "InCommon"
 msgstr "InCommon"

--- a/locales/el/LC_MESSAGES/discopower.po
+++ b/locales/el/LC_MESSAGES/discopower.po
@@ -37,7 +37,7 @@ msgid "{discopower:tabs:sweden}"
 msgstr "Σουηδία"
 
 msgid "{discopower:tabs:edugain}"
-msgstr "Ευρώπη (eduGAIN)"
+msgstr "eduGAIN"
 
 msgid "{discopower:tabs:iceland}"
 msgstr "Ισλανδία"
@@ -87,8 +87,8 @@ msgstr "Άλλοι φορείς"
 msgid "Finland"
 msgstr "Φινλανδία"
 
-msgid "Europe (eduGAIN)"
-msgstr "Ευρώπη (eduGAIN)"
+msgid "eduGAIN"
+msgstr "eduGAIN"
 
 msgid "InCommon"
 msgstr "InCommon"

--- a/locales/en/LC_MESSAGES/discopower.po
+++ b/locales/en/LC_MESSAGES/discopower.po
@@ -40,7 +40,7 @@ msgid "{discopower:tabs:sweden}"
 msgstr "Sweden"
 
 msgid "{discopower:tabs:edugain}"
-msgstr "Europe (eduGAIN)"
+msgstr "eduGAIN"
 
 msgid "{discopower:tabs:iceland}"
 msgstr "Iceland"
@@ -90,8 +90,8 @@ msgstr "Miscellaneous"
 msgid "Finland"
 msgstr "Finland"
 
-msgid "Europe (eduGAIN)"
-msgstr "Europe (eduGAIN)"
+msgid "eduGAIN"
+msgstr "eduGAIN"
 
 msgid "InCommon"
 msgstr "InCommon"

--- a/locales/es/LC_MESSAGES/discopower.po
+++ b/locales/es/LC_MESSAGES/discopower.po
@@ -37,7 +37,7 @@ msgid "{discopower:tabs:sweden}"
 msgstr "Suecia"
 
 msgid "{discopower:tabs:edugain}"
-msgstr "Europa (eduGAIN)"
+msgstr "eduGAIN"
 
 msgid "{discopower:tabs:iceland}"
 msgstr "Islandia"
@@ -87,8 +87,8 @@ msgstr "Otros"
 msgid "Finland"
 msgstr "Finlandia"
 
-msgid "Europe (eduGAIN)"
-msgstr "Europa (eduGAIN)"
+msgid "eduGAIN"
+msgstr "eduGAIN"
 
 msgid "InCommon"
 msgstr "InCommon"

--- a/locales/gl/LC_MESSAGES/discopower.po
+++ b/locales/gl/LC_MESSAGES/discopower.po
@@ -31,7 +31,7 @@ msgid "{discopower:tabs:sweden}"
 msgstr "Suecia"
 
 msgid "{discopower:tabs:edugain}"
-msgstr "Europa (eduGAIN)"
+msgstr "eduGAIN"
 
 msgid "{discopower:tabs:iceland}"
 msgstr "Islandia"
@@ -72,6 +72,6 @@ msgstr "Miscelanea"
 msgid "Finland"
 msgstr "Finlandia"
 
-msgid "Europe (eduGAIN)"
-msgstr "Europa (eduGAIN)"
+msgid "eduGAIN"
+msgstr "eduGAIN"
 

--- a/locales/nl/LC_MESSAGES/discopower.po
+++ b/locales/nl/LC_MESSAGES/discopower.po
@@ -40,7 +40,7 @@ msgid "{discopower:tabs:sweden}"
 msgstr "Zweden"
 
 msgid "{discopower:tabs:edugain}"
-msgstr "Europa (eduGAIN)"
+msgstr "eduGAIN"
 
 msgid "{discopower:tabs:iceland}"
 msgstr "IJsland"
@@ -93,8 +93,8 @@ msgstr "Overige"
 msgid "Finland"
 msgstr "Finland"
 
-msgid "Europe (eduGAIN)"
-msgstr "Europa (eduGAIN)"
+msgid "eduGAIN"
+msgstr "eduGAIN"
 
 msgid "InCommon"
 msgstr "InCommon"

--- a/locales/ru/LC_MESSAGES/discopower.po
+++ b/locales/ru/LC_MESSAGES/discopower.po
@@ -35,7 +35,7 @@ msgid "{discopower:tabs:southafrica}"
 msgstr "Южная Африка"
 
 msgid "{discopower:tabs:edugain}"
-msgstr "Европа (eduGAIN)"
+msgstr "eduGAIN"
 
 msgid "{discopower:tabs:iceland}"
 msgstr "Исландия"
@@ -79,6 +79,6 @@ msgstr "Разное"
 msgid "Finland"
 msgstr "Финляндия"
 
-msgid "Europe (eduGAIN)"
-msgstr "Европа (eduGAIN)"
+msgid "eduGAIN"
+msgstr "eduGAIN"
 

--- a/locales/xh/LC_MESSAGES/discopower.po
+++ b/locales/xh/LC_MESSAGES/discopower.po
@@ -39,7 +39,7 @@ msgid "{discopower:tabs:greece}"
 msgstr "Grisi"
 
 msgid "{discopower:tabs:edugain}"
-msgstr "Yurophu (eduGAIN)"
+msgstr "eduGAIN"
 
 msgid "{discopower:tabs:norway}"
 msgstr "Norowe"

--- a/locales/zh-tw/LC_MESSAGES/discopower.po
+++ b/locales/zh-tw/LC_MESSAGES/discopower.po
@@ -34,7 +34,7 @@ msgid "{discopower:tabs:southafrica}"
 msgstr "南非"
 
 msgid "{discopower:tabs:edugain}"
-msgstr "歐洲 (eduGAIN)"
+msgstr "eduGAIN"
 
 msgid "{discopower:tabs:iceland}"
 msgstr "冰島"
@@ -81,8 +81,8 @@ msgstr "雜項"
 msgid "Finland"
 msgstr "芬蘭"
 
-msgid "Europe (eduGAIN)"
-msgstr "歐洲 (eduGAIN)"
+msgid "eduGAIN"
+msgstr "eduGAIN"
 
 msgid "InCommon"
 msgstr "InCommon"

--- a/locales/zu/LC_MESSAGES/discopower.po
+++ b/locales/zu/LC_MESSAGES/discopower.po
@@ -33,7 +33,7 @@ msgid "{discopower:tabs:iceland}"
 msgstr "I-Iceland"
 
 msgid "{discopower:tabs:edugain}"
-msgstr "IYurophu (eduGAIN)"
+msgstr "eduGAIN"
 
 msgid "{discopower:tabs:norway}"
 msgstr "ENorway"


### PR DESCRIPTION
eduGAIN currently has 66 members, of which 33 are not countries in Europe.  Thus listing eduGAIN as "Europe (eduGAIN)" is now somewhat misleading :-)