### PR TITLE
Allow protocol bridges to filter based on SP metadata

### DIFF
--- a/config-templates/module_discopower.php
+++ b/config-templates/module_discopower.php
@@ -42,4 +42,13 @@ $config = [
      * Example: 'cdc.lifetime' => 180*24*60*60, // 180 days
      */
     'cdc.lifetime' => null,
+
+    /*
+     * If you are configuring a protocol bridge, setting this to `true` will
+     * parse the URL return parameter and use it to find 'discopower.filter'
+     * configuration in SP metadata on the other side of the bridge.
+     * Because it introduces a small risk, the default is `false`.
+     *
+     * 'useunsafereturn' => false,
+     */
 ];


### PR DESCRIPTION
If you use SSP as a protocol bridge or SP proxy then it is useful to be able to filter the list of IdPs presented based on the particular SP that's accessing the other side of the bridge. However there's current no way to determine this.

This introduces an admittedly crude solution that's been simultaneously developed by two different organisations attempting to do this. Rather than maintaining our own patch sets and because it may be useful to others trying to solve this, I'm proposing including it in the stock code.

Because of the nature of the solution, I've made it so that needs to be explicitly turned on in the config file -- the default behaviour is not to enable it (and thus retain existing behaviour). This reduces any risk that parsing the URL may inadvertently introduce (although, as noted in the comments, I'm fairly sure it is safe anyway).