### PR TITLE
Allow the setting of weights in metadata to influence sorting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# Editor configuration normalization
+# @see http://editorconfig.org/
+
+# This is the top-most .editorconfig file; do not search in parent directories.
+root = true
+
+# All files.
+[*]
+end_of_line = LF
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+composer.lock
+.phpunit.result.cache
+vendor
+build

--- a/config-templates/module_discopower.php
+++ b/config-templates/module_discopower.php
@@ -21,6 +21,15 @@ $config = [
      */
 
     /*
+     * The 'defaultweight' parameter is used to determine the sort weight when
+     * 'discopower.weight' is not explicitly set for the entity, and allows you
+     * to influence the sorting of the otherwise alphabetical display. Larger
+     * values appear higher up than smaller ones. The default defaultweight is 50.
+     *
+     * 'defaultweight' => 50,
+     */
+
+    /*
      * If you want to change the scoring algorithm to a more google suggest like one
      * (filters by start of words) uncomment this ...
      *

--- a/config-templates/module_discopower.php
+++ b/config-templates/module_discopower.php
@@ -24,9 +24,9 @@ $config = [
      * The 'defaultweight' parameter is used to determine the sort weight when
      * 'discopower.weight' is not explicitly set for the entity, and allows you
      * to influence the sorting of the otherwise alphabetical display. Larger
-     * values appear higher up than smaller ones. The default defaultweight is 50.
+     * values appear higher up than smaller ones. The default defaultweight is 100.
      *
-     * 'defaultweight' => 50,
+     * 'defaultweight' => 100,
      */
 
     /*

--- a/lib/PowerIdPDisco.php
+++ b/lib/PowerIdPDisco.php
@@ -49,7 +49,7 @@ class PowerIdPDisco extends \SimpleSAML\XHTML\IdPDisco
      *
      * @var int|null
      */
-     static $defaultWeight = 50;
+     static $defaultWeight = 100;
 
     /**
      * Initializes this discovery service.
@@ -73,7 +73,7 @@ class PowerIdPDisco extends \SimpleSAML\XHTML\IdPDisco
 
         $this->cdcLifetime = $this->discoconfig->getInteger('cdc.lifetime', null);
 
-        self::$defaultWeight = $this->discoconfig->getInteger('defaultweight', 50);
+        self::$defaultWeight = $this->discoconfig->getInteger('defaultweight', 100);
     }
 
 

--- a/lib/PowerIdPDisco.php
+++ b/lib/PowerIdPDisco.php
@@ -164,6 +164,8 @@ class PowerIdPDisco extends \SimpleSAML\XHTML\IdPDisco
 
         foreach ($slist as $tab => $tbslist) {
             uasort($slist[$tab], [self::class, 'mcmp']);
+            // reorder with a hook if one exists
+            \SimpleSAML\Module::callHooks('discosort', $slist[$tab]);
         }
 
         return $slist;

--- a/lib/PowerIdPDisco.php
+++ b/lib/PowerIdPDisco.php
@@ -85,8 +85,10 @@ class PowerIdPDisco extends \SimpleSAML\XHTML\IdPDisco
     /**
      * Compare two entities.
      *
-     * This function is used to sort the entity list. It sorts based on english name, and will always put IdP's with
-     * names configured before those with only an entityID.
+     * This function is used to sort the entity list. It sorts based on weights,
+     * and where those aren't available, English name. It puts larger weights
+     * higher, and will always put IdP's with names configured before those with
+     * only an entityID.
      *
      * @param array $a The metadata of the first entity.
      * @param array $b The metadata of the second entity.
@@ -95,7 +97,18 @@ class PowerIdPDisco extends \SimpleSAML\XHTML\IdPDisco
      */
     public static function mcmp(array $a, array $b): int
     {
-        if (isset($a['name']['en']) && isset($b['name']['en'])) {
+        // default weights
+        if (!isset($a['discopower.weight']) || !is_int($a['discopower.weight'])) {
+            $a['discopower.weight'] = $this->discoconfig->getInteger('defaultweight', 50);
+        }
+        if (!isset($b['discopower.weight']) || !is_int($b['discopower.weight'])) {
+            $b['discopower.weight'] = $this->discoconfig->getInteger('defaultweight', 50);
+        }
+        if ($a['discopower.weight'] > $b['discopower.weight']) {
+            return -1; // higher weights further up
+        } elseif ($b['discopower.weight'] > $a['discopower.weight']) {
+            return 1; // lower weights further down
+        } elseif (isset($a['name']['en']) && isset($b['name']['en'])) {
             return strcasecmp($a['name']['en'], $b['name']['en']);
         } elseif (isset($a['name']['en'])) {
             return -1; // place name before entity ID

--- a/lib/PowerIdPDisco.php
+++ b/lib/PowerIdPDisco.php
@@ -45,6 +45,13 @@ class PowerIdPDisco extends \SimpleSAML\XHTML\IdPDisco
 
 
     /**
+     * The default sort weight for entries without 'discopower.weight'.
+     *
+     * @var int|null
+     */
+     static $defaultWeight = 50;
+
+    /**
      * Initializes this discovery service.
      *
      * The constructor does the parsing of the request. If this is an invalid request, it will throw an exception.
@@ -65,6 +72,8 @@ class PowerIdPDisco extends \SimpleSAML\XHTML\IdPDisco
         }
 
         $this->cdcLifetime = $this->discoconfig->getInteger('cdc.lifetime', null);
+
+        self::$defaultWeight = $this->discoconfig->getInteger('defaultweight', 50);
     }
 
 
@@ -99,10 +108,10 @@ class PowerIdPDisco extends \SimpleSAML\XHTML\IdPDisco
     {
         // default weights
         if (!isset($a['discopower.weight']) || !is_int($a['discopower.weight'])) {
-            $a['discopower.weight'] = $this->discoconfig->getInteger('defaultweight', 50);
+            $a['discopower.weight'] = self::$defaultWeight;
         }
         if (!isset($b['discopower.weight']) || !is_int($b['discopower.weight'])) {
-            $b['discopower.weight'] = $this->discoconfig->getInteger('defaultweight', 50);
+            $b['discopower.weight'] = self::$defaultWeight;
         }
         if ($a['discopower.weight'] > $b['discopower.weight']) {
             return -1; // higher weights further up

--- a/tests/lib/PowerIdPDiscoTest.php
+++ b/tests/lib/PowerIdPDiscoTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace SimpleSAML\Test\Module\discopower;
+
+use PHPUnit\Framework\TestCase;
+use SAML2\Constants;
+use SimpleSAML\Module\discopower\PowerIdPDisco;
+use SimpleSAML\Configuration;
+use SimpleSAML\Metadata\MetaDataStorageHandler;
+
+class PowerIdPDiscoTest extends TestCase
+{
+    private $discoHandler;
+    private $config;
+    private $discoConfig;
+    private $idpList;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->config = Configuration::loadFromArray([
+            'module.enable' => ['discopower' => true],
+            'metadata.sources' => [
+                ['type' => 'flatfile', 'directory' => __DIR__. '/test-metadata'],
+            ],
+        ], '[ARRAY]', 'simplesaml');
+        Configuration::setPreLoadedConfig($this->config, 'config.php');
+
+        $this->discoConfig = Configuration::loadFromArray([
+            'defaulttab' => 0,
+            'taborder' => ['B', 'A'],
+        ], '[ARRAY]', 'module_discopower');
+        Configuration::setPreLoadedConfig($this->discoConfig, 'module_discopower.php');
+
+        /* spoof the request*/
+        $_GET['entityID'] = 'https://sp01.example.net/sp';
+        $_GET['return'] = 'https://sp01.example.net/simplesaml/module.php/saml/sp/discoresp.php';
+        $_GET['returnIDParam'] = 'idpentityid';
+        $_SERVER['SERVER_NAME'] = 'sp01.example.net';
+        $_SERVER['REQUEST_URI'] = '/simplesaml/module.php/discopower/disco.php';
+
+        $this->discoHandler = new PowerIdPDisco(
+            ['saml20-idp-remote'],
+            'poweridpdisco'
+        );
+
+        $this->idpList = MetaDataStorageHandler::getMetadataHandler()->getList('saml20-idp-remote');
+    }
+
+    /**
+     * @covers \SimpleSAML\Module\discopower\PowerIdPDisco
+     * @covers \SimpleSAML\Module\discopower\PowerIdPDisco::__construct
+     * @return void
+     */
+    public function testPowerIdPDisco(): void
+    {
+        $this->assertInstanceOf('\SimpleSAML\Module\discopower\PowerIdPDisco', $this->discoHandler);
+    }
+
+    /**
+     * @covers \SimpleSAML\Module\discopower\PowerIdPDisco::getIdPList
+     * @return void
+     */
+    public function testGetIdPList(): void
+    {
+        $refl = new \ReflectionClass($this->discoHandler);
+        $getIdPList = $refl->getMethod('getIdPList');
+        $getIdPList->setAccessible(true);
+        $idpList = $getIdPList->invoke($this->discoHandler);
+
+        $this->assertEquals($this->idpList, $idpList);
+    }
+
+    /**
+     * @covers \SimpleSAML\Module\discopower\PowerIdPDisco::idplistStructured
+     * @covers \SimpleSAML\Module\discopower\PowerIdPDisco::getIdPList
+     * @covers \SimpleSAML\Module\discopower\PowerIdPDisco::mcmp
+     * @return void
+     */
+    public function testIdplistStructured(): void
+    {
+        $refl = new \ReflectionClass($this->discoHandler);
+        $idplistStructured = $refl->getMethod('idplistStructured');
+        $idplistStructured->setAccessible(true);
+        $idpList = $idplistStructured->invokeArgs($this->discoHandler, [$this->idpList]);
+
+         $expected = [
+            'B' => [
+                'https://idp04.example.org' => ['name' => ['en' => 'IdP 04'], 'tags' => ['A', 'B'], 'entityid' => 'https://idp04.example.org'],
+                'https://idp06.example.org' => ['name' => ['en' => 'IdP 06'], 'tags' => ['B'], 'entityid' => 'https://idp06.example.org'],
+                'https://idp05.example.org' => ['tags' => ['B'], 'entityid' => 'https://idp05.example.org'],
+            ],
+            'A' => [
+                'https://idp03.example.org' => ['name' => ['en' => 'IdP 03'], 'discopower.weight' => 100, 'tags' => ['A'], 'entityid' => 'https://idp03.example.org'],
+                'https://idp02.example.org' => ['name' => ['en' => 'IdP 02'], 'tags' => ['A'], 'entityid' => 'https://idp02.example.org'],
+                'https://idp04.example.org' => ['name' => ['en' => 'IdP 04'], 'tags' => ['A','B',], 'entityid' => 'https://idp04.example.org'],
+                'https://idp01.example.org' => ['name' => ['en' => 'IdP 01'], 'discopower.weight' => 1, 'tags' => ['A'], 'entityid' => 'https://idp01.example.org'],
+            ],
+        ];
+        $this->assertEquals($expected, $idpList);
+        $this->assertEquals($expected['A'], $idpList['A']);
+        $this->assertEquals($expected['B'], $idpList['B']);
+    }
+
+    /**
+     * @covers \SimpleSAML\Module\discopower\PowerIdPDisco::mcmp
+     * @return void
+     */
+    public function testmcmp(): void
+    {
+        $this->assertEquals(-1, PowerIdPDisco::mcmp(['name' => 'B', 'entityid' => '1'], ['name' => 'A', 'entityid' => '2']), 'name,name');
+        $this->assertEquals(-1, PowerIdPDisco::mcmp(['entityid' => '1'], ['name' => 'A', 'entityid' => '2']), 'entityid,name');
+        $this->assertEquals(1, PowerIdPDisco::mcmp(['entityid' => '2'], ['entityid' => '1']), 'entityid,entityid');
+        $this->assertEquals(-1, PowerIdPDisco::mcmp(['name' => 'B', 'entityid' => '1', 'discopower.weight' => 100], ['name' => 'A', 'entityid' => '2']), 'weight,name');
+        $this->assertEquals(1, PowerIdPDisco::mcmp(['name' => 'B', 'entityid' => '1', 'discopower.weight' => 100], ['name' => 'A', 'entityid' => '2', 'discopower.weight' => 200]), 'weight,weight');
+    }
+
+}

--- a/tests/lib/test-metadata/saml20-idp-remote.php
+++ b/tests/lib/test-metadata/saml20-idp-remote.php
@@ -1,0 +1,27 @@
+<?php
+$metadata['https://idp01.example.org'] = [
+    'name' => ['en' => 'IdP 01'],
+    'discopower.weight' => 1,
+    'tags' => ['A'],
+];
+$metadata['https://idp02.example.org'] = [
+    'name' => ['en' => 'IdP 02'],
+    'tags' => ['A'],
+];
+$metadata['https://idp03.example.org'] = [
+    'name' => ['en' => 'IdP 03'],
+    'discopower.weight' => 100,
+    'tags' => ['A'],
+];
+$metadata['https://idp04.example.org'] = [
+    'name' => ['en' => 'IdP 04'],
+    'tags' => ['A', 'B'],
+];
+$metadata['https://idp05.example.org'] = [
+    'tags' => ['B'],
+];
+$metadata['https://idp06.example.org'] = [
+    'name' => ['en' => 'IdP 06'],
+    'tags' => ['B'],
+];
+


### PR DESCRIPTION
By default, discopower sorts the display alphabetically by English name. This is good where there are lots of identity providers, but where there are smaller numbers (eg social providers) it may be desirable to override the sort order to influence user behaviour.

This introduces a `discopower.weight` to all entries to be weighted so that they appear higher or lower than they normally would.

If `discopower.weight` is not set, the value of `defaultweight` from the configuration is used. This allows us to push up or down a single entry with ease, as all others remain sorted alphabetically (and equal weights are always alphabetical).

If no weights are set, the previous behaviour remains unchanged.