### PR TITLE
Move HTML generation into template. 

### DIFF
--- a/templates/disco.twig
+++ b/templates/disco.twig
@@ -50,7 +50,7 @@
               <a class="metaentry{% if entity == faventry %} favourite{% endif %}"
                   href="{{ entity.actionUrl }}">{{ entity|entityDisplayName }}
               {% if entity.iconUrl is defined %}
-                    <img alt="Icon for identity provider" class="entryicon" src="{{ entity.iconUrl}}" loading="lazy">
+                    <img alt="Icon for identity provider" class="entryicon" src="{{ entity.iconUrl }}" loading="lazy">
               {% endif %}
               </a>
           {% endfor %}

--- a/templates/disco.twig
+++ b/templates/disco.twig
@@ -15,13 +15,13 @@
 {% block content %}
     {% if faventry is not empty %}
     <div class="favourite">{{ '{disco:previous_auth}'|trans }}
-        <strong>{{ faventry.translated|escape('html') }}</strong><br>
+        <strong>{{ faventry|entityDisplayName }}</strong><br>
         <form id="idpselectform" class="pure-form" method="get" action="{{ urlpattern }}">
-            <input type="hidden" name="entityID" value="{{ entityID|escape('html') }}">
-            <input type="hidden" name="return" value="{{ return|escape('html') }}">
-            <input type="hidden" name="returnIDParam" value="{{ returnIDParam|escape('html') }}">
-            <input type="hidden" name="idpentityid" value="{{ faventry.entityid|escape('html') }}">
-            <input type="submit" name="formsubmit" id="favouritesubmit" value="{{ '{disco:login_at}'|trans }} {{ faventry.translated|escape('html') }}" class="pure-button pure-button-primary">
+            <input type="hidden" name="entityID" value="{{ entityID }}">
+            <input type="hidden" name="return" value="{{ return }}">
+            <input type="hidden" name="returnIDParam" value="{{ returnIDParam }}">
+            <input type="hidden" name="idpentityid" value="{{ faventry.entityid }}">
+            <input type="submit" name="formsubmit" id="favouritesubmit" value="{{ '{disco:login_at}'|trans }} {{ faventry|entityDisplayName }}" class="pure-button pure-button-primary">
     </form>
     </div>
     {% endif %}
@@ -42,12 +42,17 @@
           <div class="inlinesearch">
               <p>{{ '{discopower:tabs:incremental_search}'|trans }}</p>
               <form id="idpselectform" method="get">
-                  <input class="inlinesearch" type="text" value="" name="query_{{ tab }}" id="query_{{ tab }}" />
+                  <input class="inlinesearch" type="text" value="" name="query_{{ tab }}" id="query_{{ tab }}">
               </form>
           </div>
           <div class="metalist" id="list_{{ tab }}">
           {% for entityid, entity in idps %}
-              {{ entity.html|raw }}
+              <a class="metaentry{% if entity == faventry %} favourite{% endif %}"
+                  href="{{ entity.actionUrl }}">{{ entity|entityDisplayName }}
+              {% if entity.iconUrl is defined %}
+                    <img alt="Icon for identity provider" class="entryicon" src="{{ entity.iconUrl}}" loading="lazy">
+              {% endif %}
+              </a>
           {% endfor %}
           </div>
           </div>


### PR DESCRIPTION
Remove dependency on legacy translator functions.

Clean up template a bit and load any entity icons lazily.

Needs https://github.com/simplesamlphp/simplesamlphp/pull/1512