### PR TITLE
Include keywords from UIInfo in DiscoPower search.

### DIFF
--- a/lib/PowerIdPDisco.php
+++ b/lib/PowerIdPDisco.php
@@ -8,7 +8,6 @@ use Exception;
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\Auth;
 use SimpleSAML\Configuration;
-use SimpleSAML\Locale\Language;
 use SimpleSAML\Locale\Translate;
 use SimpleSAML\Logger;
 use SimpleSAML\Module;
@@ -310,7 +309,7 @@ class PowerIdPDisco extends IdPDisco
         $t->data['entityID'] = $this->spEntityId;
         $t->data['defaulttab'] = $this->discoconfig->getValue('defaulttab', 0);
 
-        $idpList = $this->processMetadata($t, $translator->getLanguage()->getLanguage(), $idpList);
+        $idpList = $this->processMetadata($t, $idpList);
 
         $t->data['idplist'] = $idpList;
         $t->data['faventry'] = null;
@@ -353,11 +352,10 @@ class PowerIdPDisco extends IdPDisco
 
     /**
      * @param \SimpleSAML\XHTML\Template $t
-     * @param string $lang Currently selected language
      * @param array $metadata
      * @return array
      */
-    private function processMetadata(Template $t, string $lang, array $metadata): array
+    private function processMetadata(Template $t, array $metadata): array
     {
         $basequerystring = '?' .
             'entityID=' . urlencode($t->data['entityID']) . '&' .
@@ -372,9 +370,7 @@ class PowerIdPDisco extends IdPDisco
                     $entity['iconUrl'] = $httpUtils->resolveURL($entity['icon']);
                 }
                 $entity['keywords'] = implode(' ',
-                    $entity['UIInfo']['Keywords'][$lang] ??
-                    $entity['UIInfo']['Keywords'][Language::FALLBACKLANGUAGE] ??
-                    []
+                    $t->getEntityPropertyTranslation('Keywords', $entity['UIInfo'] ?? []) ?? []
                 );
                 $metadata[$tab][$entityid] = $entity;
             }

--- a/lib/PowerIdPDisco.php
+++ b/lib/PowerIdPDisco.php
@@ -8,6 +8,7 @@ use Exception;
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\Auth;
 use SimpleSAML\Configuration;
+use SimpleSAML\Locale\Language;
 use SimpleSAML\Locale\Translate;
 use SimpleSAML\Logger;
 use SimpleSAML\Module;
@@ -309,7 +310,7 @@ class PowerIdPDisco extends IdPDisco
         $t->data['entityID'] = $this->spEntityId;
         $t->data['defaulttab'] = $this->discoconfig->getValue('defaulttab', 0);
 
-        $idpList = $this->processMetadata($t, $idpList);
+        $idpList = $this->processMetadata($t, $translator->getLanguage()->getLanguage(), $idpList);
 
         $t->data['idplist'] = $idpList;
         $t->data['faventry'] = null;
@@ -352,10 +353,11 @@ class PowerIdPDisco extends IdPDisco
 
     /**
      * @param \SimpleSAML\XHTML\Template $t
+     * @param string $lang Currently selected language
      * @param array $metadata
      * @return array
      */
-    private function processMetadata(Template $t, array $metadata): array
+    private function processMetadata(Template $t, string $lang, array $metadata): array
     {
         $basequerystring = '?' .
             'entityID=' . urlencode($t->data['entityID']) . '&' .
@@ -369,6 +371,11 @@ class PowerIdPDisco extends IdPDisco
                 if (array_key_exists('icon', $entity) && $entity['icon'] !== null) {
                     $entity['iconUrl'] = $httpUtils->resolveURL($entity['icon']);
                 }
+                $entity['keywords'] = implode(' ',
+                    $entity['UIInfo']['Keywords'][$lang] ??
+                    $entity['UIInfo']['Keywords'][Language::FALLBACKLANGUAGE] ??
+                    []
+                );
                 $metadata[$tab][$entityid] = $entity;
             }
         }

--- a/templates/disco.twig
+++ b/templates/disco.twig
@@ -48,7 +48,8 @@
           <div class="metalist" id="list_{{ tab }}">
           {% for entityid, entity in idps %}
               <a class="metaentry{% if entity == faventry %} favourite{% endif %}"
-                  href="{{ entity.actionUrl }}">{{ entity|entityDisplayName }}
+                  href="{{ entity.actionUrl }}"
+                  data-keywords="{{ entity.keywords }}">{{ entity|entityDisplayName }}
               {% if entity.iconUrl is defined %}
                     <img alt="Icon for identity provider" class="entryicon" src="{{ entity.iconUrl }}" loading="lazy">
               {% endif %}

--- a/tests/lib/PowerIdPDiscoTest.php
+++ b/tests/lib/PowerIdPDiscoTest.php
@@ -97,12 +97,14 @@ class PowerIdPDiscoTest extends TestCase
                 'https://idp04.example.org' => [
                     'name' => ['en' => 'IdP 04'],
                     'tags' => ['A', 'B'],
-                    'entityid' => 'https://idp04.example.org'
+                    'entityid' => 'https://idp04.example.org',
+                    'UIInfo' => ['Keywords' => ['en' => ['aap','noot','mies']]],
                 ],
                 'https://idp06.example.org' => [
                     'name' => ['en' => 'IdP 06'],
                     'tags' => ['B'],
-                    'entityid' => 'https://idp06.example.org'
+                    'entityid' => 'https://idp06.example.org',
+                    'UIInfo' => ['Keywords' => ['fr' => ['singue','noix','mies'], 'de' => ['Affe', 'Nuss', 'mies']]],
                 ],
                 'https://idp05.example.org' => [
                     'tags' => ['B'],
@@ -124,7 +126,8 @@ class PowerIdPDiscoTest extends TestCase
                 'https://idp04.example.org' => [
                     'name' => ['en' => 'IdP 04'],
                     'tags' => ['A','B',],
-                    'entityid' => 'https://idp04.example.org'
+                    'entityid' => 'https://idp04.example.org',
+                    'UIInfo' => ['Keywords' => ['en' => ['aap','noot','mies']]],
                 ],
                 'https://idp01.example.org' => [
                     'name' => ['en' => 'IdP 01'],

--- a/tests/lib/test-metadata/saml20-idp-remote.php
+++ b/tests/lib/test-metadata/saml20-idp-remote.php
@@ -16,6 +16,7 @@ $metadata['https://idp03.example.org'] = [
 ];
 $metadata['https://idp04.example.org'] = [
     'name' => ['en' => 'IdP 04'],
+    'UIInfo' => ['Keywords' => ['en' => ['aap','noot','mies']]],
     'tags' => ['A', 'B'],
 ];
 $metadata['https://idp05.example.org'] = [
@@ -23,5 +24,6 @@ $metadata['https://idp05.example.org'] = [
 ];
 $metadata['https://idp06.example.org'] = [
     'name' => ['en' => 'IdP 06'],
+    'UIInfo' => ['Keywords' => ['fr' => ['singue','noix','mies'], 'de' => ['Affe', 'Nuss', 'mies']]],
     'tags' => ['B'],
 ];

--- a/www/assets/js/jquery.livesearch.js
+++ b/www/assets/js/jquery.livesearch.js
@@ -4,7 +4,8 @@ jQuery.fn.liveUpdate = function (list) {
     if (list.length) {
         var rows = list.children('a'),
         cache = rows.map(function () {
-            return jQuery(this).text().toLowerCase();
+            var keywords = jQuery(this).attr('data-keywords') || "";
+            return jQuery(this).text().toLowerCase() + " " + keywords.toLowerCase();
         });
 
         this.keyup(filter).keyup().parents('form').submit(function () {


### PR DESCRIPTION
If an entity has any UIInfo.Keywords set for the current language, or for English, it will be added to this entity's search text which is used when using the typeahead search in the search box. Any match on a keyword will then count the same as a match on words in the entity name.